### PR TITLE
Make sure condor_chirp is in $PATH

### DIFF
--- a/set_home_cms.source
+++ b/set_home_cms.source
@@ -1,3 +1,13 @@
 export OSG_WN_TMP=$PWD
 export _CONDOR_SCRATCH_DIR=$PWD
 export HOME=$PWD
+
+# Make sure condor_chirp is available
+
+if [ -e "$CONDOR_CONFIG" ]; then
+  BASE=`dirname $CONDOR_CONFIG`/main/condor/libexec
+  if [ -d "$BASE" ]; then
+    export PATH=$BASE:$PATH
+  fi
+fi
+


### PR DESCRIPTION
CRAB3 has always wanted to use condor_chirp, but it's not in $PATH - meaning that, despite the fact gWMS ships condor_chirp, it's never been used.

This should fix that fact.