### PR TITLE
Advertise information from SITECONF

### DIFF
--- a/CMSGroupMapper.py
+++ b/CMSGroupMapper.py
@@ -1,0 +1,114 @@
+
+import os
+import re
+import time
+
+g_expire_time = 0
+g_cache = {}
+g_site_cache = {}
+
+# Set to false to consider 'local' as a valid sitename.
+# Useful mostly for testing purposes.
+g_ignore_local = True
+
+def cache_users():
+    global g_cache
+
+    base_dir = '/cvmfs/cms.cern.ch/SITECONF'
+    cache = {}
+    user_re = re.compile(r'[-_A-Za-z0-9.]+')
+    sites = None
+    try:
+        if os.path.isdir(base_dir):
+            sites = os.listdir(base_dir)
+    except:
+        pass
+    if not sites:
+        return
+    for entry in sites:
+        full_path = os.path.join(base_dir, entry, 'GlideinConfig', 'local-users.txt')
+        if g_ignore_local and (entry == 'local'):
+            continue
+        if not os.path.isfile(full_path):
+            continue
+        try:
+            fd = open(full_path)
+            for line in fd:
+                line = line.strip()
+                if user_re.match(line):
+                    group_set = cache.setdefault(line, set())
+                    group_set.add(entry)
+        except:
+            pass
+    for key, val in cache.items():
+        cache[key] = (",".join(val), val)
+
+    g_cache = cache
+
+
+def cache_sites():
+    global g_site_cache
+
+    base_dir = '/cvmfs/cms.cern.ch/SITECONF'
+    cache = {}
+    user_re = re.compile(r'[-_A-Za-z0-9.]+')
+    sites = None
+    try:
+        if os.path.isdir(base_dir):
+            sites = os.listdir(base_dir)
+    except:
+        pass
+    if not sites:
+        g_expire_time = time.time() + 60
+        return
+    for entry in sites:
+        full_path = os.path.join(base_dir, entry, 'GlideinConfig', 'local-users.txt')
+        if g_ignore_local and (entry == 'local'):
+            continue
+        if not os.path.isfile(full_path):
+            continue
+        groups = cache.setdefault(entry, set())
+        groups.add(entry)
+        try:
+            valid_group_re = re.compile(r"[-_A-Za-z0-9]+")
+            if os.path.exists(local_gconf):
+                for line in open(local_gconf).xreadlines():
+                    line = line.strip()
+                    if valid_group_re.match(line):
+                        groups.add(line)
+        except:
+            pass
+    for key, val in cache.items():
+        cache[key] = (",".join(val), val)
+
+    g_site_cache = cache
+
+
+def check_caches():
+    global g_expire_time
+    if time.time() > g_expire_time:
+        cache_users()
+        cache_sites()
+        g_expire_time = time.time() + 15*3600
+
+
+def map_user_to_groups(user):
+    check_caches()
+    return g_cache.setdefault(user, ("", set()))[0]
+
+
+def is_local_user(user, site):
+    check_caches()
+    user_groups = g_cache.setdefault(user, ("", set()))[1]
+    site_groups = g_site_cache.setdefault(site, ("", set()))[1]
+    return bool(user_groups.intersection(site_groups))
+     
+
+if __name__ == '__main__':
+    print map_user_to_groups("bbockelm")
+    print is_local_user("bbockelm", "local")
+
+    #import classad
+    #classad.register(map_user_to_groups)
+    #print classad.ExprTree('map_user_to_groups("bbockelm")').eval()
+

--- a/export_siteconf_info.py
+++ b/export_siteconf_info.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python
+
+import os
+import re
+import sys
+import tempfile
+
+try:
+    import xml.etree.ElementTree
+except Exception, e:
+    print "Unable to import ElementTree for parsing XML."
+    print "Skipping this script; SITECONF data will be missing."
+    print "This can be ignored if this is a RHEL5 host."
+    print "Exception message: %s" % str(e)
+    sys.exit(0)
+
+
+def add_condor_config_var(glidein_config, name=None, kind="C", value=None, publish=True, condor_name=None):
+    if (name == None) or (value == None):
+        print "Invalid condor configuration specified (name=%s; value=%s)" % (str(name), str(value))
+        return
+
+    if 'CONDOR_VARS_FILE' not in glidein_config:
+        print "Warning: Missing condor vars file from configuration; ignoring (%s=%s)" % (name, value)
+        return
+
+    has_whitespace = re.compile("\s")
+    if has_whitespace.search(name):
+        print "Ignoring specified name as it contains whitespace (name=%s)." % name
+        return
+    if has_whitespace.search(value):
+        print "Ignoring specified value as it contains whitespace (value=%s)." % name
+        return
+    if condor_name and has_whitespace.search(condor_name):
+        print "Ignoring specified HTCondor variable name as it contains whitespace (condor_name=%s)." % condor_name
+        return
+
+    if condor_name == None:
+        condor_name = name
+    if publish:
+        exp_condor = "Y"
+    else:
+        exp_condor = "N"
+
+    fname = glidein_config['CONDOR_VARS_FILE']
+    vars_dir, vars_file = os.path.split(fname)
+    tempfd = tempfile.NamedTemporaryFile(dir=vars_dir, prefix=vars_file, delete=False)
+    try:
+        fd = open(fname, "r")
+        for line in fd.xreadlines():
+            if line.startswith(name):
+                continue
+            tempfd.write(line)
+        tempfd.write("%s %s %s %s Y %s -\n" % (name, kind, value, condor_name, exp_condor))
+    except:
+        os.unlink(tempfd.name)
+        raise
+    tempfd.close()
+    fd.close()
+    os.rename(tempfd.name, fname)
+
+    print "Setting value of %s to %s." % (name, value)
+
+
+def add_glidein_config(name, value):
+    if (name == None) or (value == None):
+        print "Invalid condor configuration specified (name=%s; value=%s)" % (str(name), str(value))
+        return
+
+    fname = os.environ['glidein_config']
+    conf_dir, conf_file = os.path.split(fname)
+    tempfd = tempfile.NamedTemporaryFile(dir=conf_dir, prefix=conf_file, delete=False)
+    try:
+        fd = open(fname, "r")
+        for line in fd.xreadlines():
+            if line.startswith(name):
+                continue
+            tempfd.write(line)
+        tempfd.write("%s %s\n" % (name, value))
+    except:
+        os.unlink(tempfd.name)
+        raise
+    tempfd.close()
+    os.rename(tempfd.name, fname)
+
+    print "Setting glidein config value of %s to %s." % (name, value)
+    fd.close()
+ 
+
+def create_local_glidein(glidein_config):
+    cvmfs_path = os.environ.get("CVMFS", "/cvmfs")
+    local_gconf = os.path.join(cvmfs_path, "cms.cern.ch", "SITECONF", "local", "GlideinConfig", 'local-groups.txt')
+    cmssite = glidein_config.get("GLIDEIN_CMSSite")
+
+    if not os.path.exists(local_gconf) and not cmssite:
+        print "WARNING: Local group name list (%s) does not exist!" % local_gconf
+        return
+
+    groups = set()
+    if cmssite:
+        groups.add(cmssite)
+    valid_group_re = re.compile(r"[-_A-Za-z0-9]+")
+    if os.path.exists(local_gconf):
+        for line in open(local_gconf).xreadlines():
+            line = line.strip()
+            if valid_group_re.match(line):
+                groups.add(line)
+
+    if not groups:
+        return
+
+    value = "stringListsIntersect(CMSGroups, %s)" % ",".join([gname for gname in groups])
+    add_glidein_config("GLIDEIN_Start", value)
+
+
+def main():
+
+    if 'glidein_config' not in os.environ:
+        print "No glidein_config environment variable present; defaulting value to 'glidein_config'"
+    os.environ.setdefault('glidein_config', 'glidein_config')
+    if not os.path.exists(os.environ['glidein_config']):
+        print "Unable to locate the glidein configuration file %s; failing script." % os.environ['glidein_config']
+        sys.exit(1)
+
+    glidein_config = {}
+    for line in open(os.environ['glidein_config'], 'r').xreadlines():
+        line = line.strip()
+        if line.startswith("#"):
+            continue
+        info = line.split(" ", 1)
+        if len(info) != 2:
+            continue
+        glidein_config[info[0]] = info[1]
+
+    cvmfs_path = os.environ.get("CVMFS", "/cvmfs")
+    local_siteconf = os.path.join(cvmfs_path, "cms.cern.ch", "SITECONF", "local")
+    if not os.path.exists(local_siteconf):
+        print "CVMFS siteconf path (%s) does not exist; is CVMFS running and configured properly?" % cvmfs_path
+
+    job_config = os.path.join(local_siteconf, "JobConfig", "site-local-config.xml")
+    if not os.path.exists(job_config):
+        print "site-local-config.xml does not exist in CVMFS (looked at %s); is CVMFS running and configured properly?" % cvmfs_path
+
+    tree = xml.etree.ElementTree.parse(job_config)
+    job_config_root = tree.getroot()
+
+    site_name = None
+    if job_config_root[0].get('name'):
+        site_name = job_config_root[0].get('name')
+
+    if site_name:
+        add_condor_config_var(glidein_config, name="CMSProcessingSiteName", kind="S", value=site_name)
+    else:
+        print "No sitename detected!  Invalid SITECONF file?"
+        sys.exit(1)
+
+    local_stage_out = job_config_root[0].find("local-stage-out")
+    pnn_found = False
+    if local_stage_out:
+        phedex_node = local_stage_out.find("phedex-node")
+        if (phedex_node != None) and phedex_node.get("value"):
+            add_condor_config_var(glidein_config, name="CMSPhedexNodeName", kind="S", value=phedex_node.get("value"))
+            pnn_found = True
+    if not pnn_found:
+        print "No PhEDEx node name found for local stageout."
+
+    fallback_stage_out = job_config_root[0].find("fallback-stage-out")
+    pnn_found = False
+    if fallback_stage_out:
+        phedex_node = fallback_stage_out.find("phedex-node")
+        if (phedex_node != None) and phedex_node.get("value"):
+            add_condor_config_var(glidein_config, name="CMSFallback_PhedexNodeName", kind="S", value=phedex_node.get("value"))
+            pnn_found = True
+    if not pnn_found:
+        print "No PhEDEx node name found for fallback stageout."
+
+    if 'GLIDEIN_CMSSite_Override' in glidein_config:
+        add_glidein_config('GLIDEIN_CMSSite', glidein_config['GLIDEIN_CMSSite_Override'])
+
+    if ('CMSIsLocal' in glidein_config) and (glidein_config['CMSIsLocal'].lower() == 'true'):
+        create_local_glidein(glidein_config)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
SITECONF holds a wealth of interesting data that we would like to expose to HTCondor via the pilot.

This includes:
- Processing Site Name (in most cases, identical to GLIDEIN_CMSSite but not hardcoded from the entry point).
  - If this proves usable, it'll make the factory folks happy - they no longer need to maintain the CMS-specific site names in the factory configs.  One less thing.
- PhEDEx site name (for stageout and fallback).
- List of allowable local groups (if the CMSIsLocal attribute is set in the glidein config).  Changes the START expression to only allows jobs belonging to the local users of the site to run on the pilot.
  - Allowed group names are taken from SITECONF; the processing site name is added as a group name by default.