### PR TITLE
Fix validation scripts for Parrot-based sites

### DIFF
--- a/discover_CMSSW.sh
+++ b/discover_CMSSW.sh
@@ -28,6 +28,7 @@ else
    echo "and /cvmfs/cms.cern.ch/cmsset_default.sh" 1>&2
    echo "and $VO_CMS_SW_DIR/cmsset_default.sh" 1>&2
    echo "and $OSG_APP/cmssoft/cms/cmsset_default.sh" 1>&2
+   echo "and \$PARROT_RUN_WORKS is set to $PARROT_RUN_WORKS" 1>&2
    exit 1
 fi
 

--- a/discover_CMSSW.sh
+++ b/discover_CMSSW.sh
@@ -2,6 +2,9 @@
 
 glidein_config="$1"
 
+
+PARROT_RUN_WORKS=`grep -i "^PARROT_RUN_WORKS " $glidein_config | awk '{print $2}'`
+
 # Look for CMSSW in CVMFS, then the older places:
 
 if [ -f "$CVMFS/cms.cern.ch/cmsset_default.sh" ]; then
@@ -16,6 +19,9 @@ elif [ -f "$VO_CMS_SW_DIR/cmsset_default.sh" ]; then
 elif [ -f "$OSG_APP/cmssoft/cms/cmsset_default.sh" ]; then
    echo "Found CMS SW in $OSG_APP/cmssoft/cms" 1>&2
    source "$OSG_APP/cmssoft/cms/cmsset_default.sh"
+elif [ "X$PARROT_RUN_WORKS" = "XTRUE" ]; then
+   echo "Pilot will use parrot for CVMFS." 1>&2
+   exit 0
 else
    echo "cmsset_default.sh not found!\n" 1>&2
    echo "Looked in $CVMFS/cms.cern.ch/cmsset_default.sh" 1>&2

--- a/export_siteconf_info.py
+++ b/export_siteconf_info.py
@@ -142,6 +142,9 @@ def main():
 
     local_siteconf = os.path.join(get_siteconf_path(), "local")
     if not os.path.exists(local_siteconf):
+        if glidein_config.get("PARROT_RUN_WORKS", "FALSE") == "TRUE":
+            print "Using parrot -- skipping SITECONF processing."
+            sys.exit(0)
         print "CVMFS siteconf path (%s) does not exist; is CVMFS running and configured properly?" % local_siteconf
     else:
         print "Using SITECONF found at %s." % local_siteconf

--- a/test_squid/test_squid.sh
+++ b/test_squid/test_squid.sh
@@ -11,6 +11,8 @@ condor_vars_file=`awk '/^CONDOR_VARS_FILE /{print $2}' $glidein_config`
 add_config_line_source=`awk '/^ADD_CONFIG_LINE_SOURCE /{print $2}' $glidein_config`
 source $add_config_line_source
 
+PARROT_RUN_WORKS=`grep -i "^PARROT_RUN_WORKS " $glidein_config | awk '{print $2}'`
+
 # big fix for glideinWMS:
 function warn {
   echo `date` $@ 1>&2
@@ -29,12 +31,16 @@ elif [ -f "$VO_CMS_SW_DIR/cmsset_default.sh" ]; then
 elif [ -f "$OSG_APP/cmssoft/cms/cmsset_default.sh" ]; then
   echo "Found CMS SW in $OSG_APP/cmssoft/cms" 1>&2
   source "$OSG_APP/cmssoft/cms/cmsset_default.sh"
+elif [ "X$PARROT_RUN_WORKS" = "XTRUE" ]; then
+   echo "Pilot will use parrot; this already checked for squid functionality." 1>&2
+   exit 0
 else
   echo "cmsset_default.sh not found!\n" 1>&2
   echo "Looked in$CVMFS/cms.cern.ch/cmsset_default.sh" 1>&2
   echo "and /cvmfs/cms.cern.ch/cmsset_default.sh" 1>&2
   echo "and $VO_CMS_SW_DIR/cmsset_default.sh" 1>&2
   echo "and $OSG_APP/cmssoft/cms/cmsset_default.sh" 1>&2
+  echo "and \$PARROT_RUN_WORKS is set to $PARROT_RUN_WORKS" 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
Various validation scripts assumed CVMFS was present.

When run at Parrot-based sites, we can skip these validation scripts because it overlaps with what Parrot does in its validation scripts.