### PR TITLE
User specific glideins

### DIFF
--- a/export_siteconf_info.py
+++ b/export_siteconf_info.py
@@ -191,7 +191,7 @@ def main():
         r = re.compile("[-._@A-Za-z0-9=/]+")
         if r.match(dn):
             print "Based on USER_DN environment variable, limiting the pilot's running jobs to user %s" % dn
-            add_glidein_config("GLIDEIN_USER", '("%s")' % dn)
+            add_glidein_config("GLIDEIN_USER", '"%s"' % dn)
             add_condor_config_var(glidein_config, name="GLIDEIN_USER", kind="C", value="-")
         else:
             print

--- a/export_siteconf_info.py
+++ b/export_siteconf_info.py
@@ -191,8 +191,8 @@ def main():
         r = re.compile("[-._@A-Za-z0-9=/]+")
         if r.match(dn):
             print "Based on USER_DN environment variable, limiting the pilot's running jobs to user %s" % dn
-            add_glidein_config("APPEND_REQ_VANILLA", '("%s" =?= x509userproxysubject)' % dn)
-            add_condor_config_var(glidein_config, name="APPEND_REQ_VANILLA", kind="C", value="-")
+            add_glidein_config("GLIDEIN_USER", '("%s")' % dn)
+            add_condor_config_var(glidein_config, name="GLIDEIN_USER", kind="C", value="-")
         else:
             print
 

--- a/get_user_requests.py
+++ b/get_user_requests.py
@@ -21,7 +21,7 @@ def get_siteconf_path():
 
 def parse_opts():
     parser = optparse.OptionParser()
-    parser.add_option("-p", "--pool", default="vocms099.cern.ch", help="HTCondor pool to query", dest="pool")
+    parser.add_option("-p", "--pool", default="cmsgwms-collector-global.cern.ch", help="HTCondor pool to query", dest="pool")
     parser.add_option("-s", "--site", help="Local site name (defaults to site configured in CVMFS)", dest="site")
     parser.add_option("-l", "--local-users", help="Location of local-users.txt", default="/cvmfs/cms.cern.ch/SITECONF/local/GlideinConfig/local-users.txt", dest="local_users")
     parser.add_option("-c", "--const", help="Schedd query constraint", default='CMSGWMS_Type =?= "crabschedd"', dest="const");


### PR DESCRIPTION
If USER_DN environment variable is defined, a GLIDEIN_USER classAd is advertised by the glidein which is then used during matchmaking to ensure only a particular user gets to use the glidein. Also, setting the collector name to generic DNS alias.