### PR TITLE
Hardcode Singularity to rhel6

### DIFF
--- a/singularity_validation.sh
+++ b/singularity_validation.sh
@@ -272,7 +272,7 @@ advertise HAS_SINGULARITY "True" "C"
 advertise OSG_SINGULARITY_VERSION "$OSG_SINGULARITY_VERSION" "S"
 advertise OSG_SINGULARITY_PATH "$OSG_SINGULARITY_PATH" "S"
 advertise OSG_SINGULARITY_IMAGE_DEFAULT "$OSG_SINGULARITY_IMAGE_DEFAULT" "S"
-advertise GLIDEIN_REQUIRED_OS "any" "S"
+advertise GLIDEIN_REQUIRED_OS "rhel6" "S"
 
 # Disable glexec if we are going to use Singularity.
 advertise GLEXEC_JOB "False" "C"


### PR DESCRIPTION
WMAgent currently adds expressions to the job's `Requirements` expression that appears incompatible with setting `GLIDEIN_REQUIRED_OS` to `any`.

In order to get production jobs to match, let's hardcode it to `rhel6`.  It's a bummer, but we can revisit easily -- and it lets us move forward.