### PR TITLE
Allow Singularity pilots to run any OS.

### DIFF
--- a/singularity_validation.sh
+++ b/singularity_validation.sh
@@ -272,7 +272,7 @@ advertise HAS_SINGULARITY "True" "C"
 advertise OSG_SINGULARITY_VERSION "$OSG_SINGULARITY_VERSION" "S"
 advertise OSG_SINGULARITY_PATH "$OSG_SINGULARITY_PATH" "S"
 advertise OSG_SINGULARITY_IMAGE_DEFAULT "$OSG_SINGULARITY_IMAGE_DEFAULT" "S"
-advertise GLIDEIN_REQUIRED_OS "rhel6" "S"
+advertise GLIDEIN_REQUIRED_OS "any" "S"
 
 # Disable glexec if we are going to use Singularity.
 advertise GLEXEC_JOB "False" "C"


### PR DESCRIPTION
WMAgent has fixed their `Requirements` expression so production jobs should match even on pilots with `GLIDEIN_Required_OS = "any"`.

This unravels the workaround we had in place to get WMAgent working on Singularity pilots.