### PR TITLE
Add support for Vanderbilt

### DIFF
--- a/singularity_wrapper.sh
+++ b/singularity_wrapper.sh
@@ -112,7 +112,7 @@ if [ "x$SINGULARITY_REEXEC" = "x" ]; then
         fi
 
         # Various possible mount points to pull into the container:
-        for VAR in /cms /hadoop /hdfs /mnt/hadoop /etc/cvmfs/SITECONF; do
+        for VAR in /lfs_roots /cms /hadoop /hdfs /mnt/hadoop /etc/cvmfs/SITECONF; do
             if [ -e "$VAR" ]; then
                 OSG_SINGULARITY_EXTRA_OPTS="$OSG_SINGULARITY_EXTRA_OPTS --bind $VAR"
             fi


### PR DESCRIPTION
While I'm still trying to figure out the best way to have new bind mount paths (without the corresponding PR here), this one-liner fixes support for Vanderbilt.

Note: I know this isn't a long-term solution, but I'm still trying to figure it out.