### PR TITLE
Handle spaces in arguments correctly

### DIFF
--- a/singularity_wrapper.sh
+++ b/singularity_wrapper.sh
@@ -163,7 +163,7 @@ if [ "x$SINGULARITY_REEXEC" = "x" ]; then
                                    --scratch /tmp \
                                    --containall \
                                    "$OSG_SINGULARITY_IMAGE" \
-                                   /srv/.osgvo-user-job-wrapper.sh $CMD
+                                   /srv/.osgvo-user-job-wrapper.sh "$CMD"
     fi
 
 else


### PR DESCRIPTION
I believe that `$CMD` should actually have double-quotes in order to preserve any arguments that themselves have spaces.

*NOTE* this requires testing by CRAB3 team before pushing to production.  Should be relatively safe (very safe for doing to ITB immediately), but this tackles a specific bug they have been chasing.