### PR TITLE
Unset `GFAL_PLUGIN_DIR`

### DIFF
--- a/singularity_wrapper.sh
+++ b/singularity_wrapper.sh
@@ -190,6 +190,10 @@ else
         fi
     done
 
+    # If the CVMFS worker node client was used, then GFAL_PLUGINS_DIR might be
+    # incompatible with our local environment.
+    unset GFAL_PLUGIN_DIR
+
     # override some OSG specific variables
     if [ "x$OSG_WN_TMP" != "x" ]; then
         export OSG_WN_TMP=/tmp


### PR DESCRIPTION
Imperial reported that the UI environment from outside the container was leaking into the Singularity container; this particular environment variable was causing `gfal-copy` to fail if a RHEL6 container was used on a RHEL7 host.