### PR TITLE
Remove extra space from command name

### DIFF
--- a/singularity_wrapper.sh
+++ b/singularity_wrapper.sh
@@ -136,7 +136,7 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
         for VAR in "$@"; do
             # two seds to make sure we catch variations of the iwd,
             # including symlinked ones
-            VAR=`echo "$VAR" | sed -E "s;$PWD(.*);/srv\1;" | sed -E "s;.*/execute/dir_[0-9a-zA-Z]*(.*);/srv\1;"`
+            VAR=`echo " $VAR" | sed -E "s;$PWD(.*);/srv\1;" | sed -E "s;.*/execute/dir_[0-9a-zA-Z]*(.*);/srv\1;" | sed -E "s;^ ;;"`
             CMD+=("$VAR")
         done
 

--- a/singularity_wrapper.sh
+++ b/singularity_wrapper.sh
@@ -136,7 +136,7 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
         for VAR in "$@"; do
             # two seds to make sure we catch variations of the iwd,
             # including symlinked ones
-            VAR=`echo " $VAR" | sed -E "s;$PWD(.*);/srv\1;" | sed -E "s;.*/execute/dir_[0-9a-zA-Z]*(.*);/srv\1;"`
+            VAR=`echo "$VAR" | sed -E "s;$PWD(.*);/srv\1;" | sed -E "s;.*/execute/dir_[0-9a-zA-Z]*(.*);/srv\1;"`
             CMD+=("$VAR")
         done
 


### PR DESCRIPTION
When `$CMD` was switched to a bash list instead of a string, bash no longer stripped off the extra '` `' character.  Thus, Singularity was attempting to execute a binary named `' foo'` instead of `'foo'`.

I was able to recreate this by logging in to a worker node with a running glidein, making a copy of the job wrapper script, and applying the patch by hand.  I was able to:
* Reproduce the errors reported by Diego in https://ggus.eu/index.php?mode=ticket_info&ticket_id=128469,
* Verify that this fix took care of the reported error.
* Verify that arguments with spaces in them appear to work.

Mystery solved, hopefully!

@rynge - it's not clear to me why the OSG pilots don't hit the same issue.  Thoughts?